### PR TITLE
add naive batching to benchmark.py

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -382,7 +382,7 @@ def main(
         gen_params["prompt"] = prompts
 
         # Print input prompt.
-        for i in range(batch):
+        for i in range(len(convs)):
             console.print(f"\n[u cyan]{'Warmup ' if is_warmup else ''}Prompt[/u cyan](batch_{i}):")
             console.print(prompts[i].strip() + "\n", markup=False)
 
@@ -411,12 +411,13 @@ def main(
             energy = measurements.total_energy
             output = {
                 "model": model_name_cleaned,
+                "batch": len(convs),
                 "throughput": throughput,
                 "response_length": response_length,
                 "latency": latency,
                 "energy": energy,
                 "input": [prompt.strip() for prompt in prompts],
-                "output": [output_text[i][:batch_token_len[i]].strip() for i in range(batch)],
+                "output": [output_text[i][:batch_token_len[i]].strip() for i in range(len(convs))],
             }
             output_str = json.dumps(output, indent=4)
             if not is_warmup:
@@ -428,7 +429,7 @@ def main(
             output_json.flush()
 
         # Print the response.
-        for i in range(batch):
+        for i in range(len(convs)):
             console.print(f"\n[u cyan]{'Warmup ' if is_warmup else ''}Response[/u cyan](batch_{i}):")
             console.print(output_text[i][:batch_token_len[i]].strip() + "\n", markup=False)
 


### PR DESCRIPTION
1. it remembers the "valid" length of each request within a batch, and prints the output for each request after all the requests in the batch finish.
2. it takes total response_length as the sum of all "valid" length within a batch, which is small than the actually output length, since the early stopped request continues to generate some garbage
3. when queries from file reaches the EOF, even if there's not enough requests to fill the batch, it still take the remaining requests in a batch and serve the batched inference, but possibly with a smaller batch size