### PR TITLE
Make one model selectable by user

### DIFF
--- a/spitfight/colosseum/common.py
+++ b/spitfight/colosseum/common.py
@@ -4,16 +4,22 @@ from typing import Literal
 
 from pydantic import BaseModel
 
+COLOSSEUM_MODELS_ROUTE = "/models"
 COLOSSEUM_PROMPT_ROUTE = "/prompt"
 COLOSSEUM_RESP_VOTE_ROUTE = "/response_vote"
 COLOSSEUM_ENERGY_VOTE_ROUTE = "/energy_vote"
 COLOSSEUM_HEALTH_ROUTE = "/health"
 
 
+class ModelsResponse(BaseModel):
+    available_models: list[str]
+
+
 class PromptRequest(BaseModel):
     request_id: str
     prompt: str
     model_index: Literal[0, 1]
+    model_preference: str
 
 
 class ResponseVoteRequest(BaseModel):

--- a/spitfight/colosseum/controller/worker.py
+++ b/spitfight/colosseum/controller/worker.py
@@ -19,7 +19,7 @@ class Worker(BaseModel):
     hostname: str
     # For TGI, this would always be 80.
     port: int
-    # User-friendly model name, e.g. "metaai/llama2-13b-chat".
+    # User-friendly model name, e.g. "Llama2-7B".
     model_name: str
     # Hugging Face model ID, e.g. "metaai/Llama-2-13b-chat-hf".
     model_id: str
@@ -145,6 +145,21 @@ class WorkerService:
             raise ValueError("Not enough live workers to choose from.")
         worker_a, worker_b = random.sample(live_workers, 2)
         return worker_a, worker_b
+
+    def choose_based_on_preference(self, preference: str) -> tuple[Worker, Worker]:
+        """Choose two different workers based on user preference.
+
+        Specifically, if `preference` is `"Random"`, this is equivalent to
+        choosing two models at random. Otherwise, if `preference` is a model
+        name, this is equivalent to choosing that model and another model at
+        random. In that case, the order of the two models is also randomized.
+        """
+        if preference == "Random":
+            return self.choose_two()
+        else:
+            worker_a = self.get_worker(preference)
+            worker_b = random.choice([worker for worker in self.workers if worker != worker_a])
+            return tuple(random.sample([worker_a, worker_b], 2))
 
     async def check_workers(self) -> None:
         """Check the status of all workers."""


### PR DESCRIPTION
This PR allows Colosseum users to select one model that they prefer.

Specifically, there's a new `gr.Dropdown` that has choices: "Two random models", "One is Llama2-7B", "One is MPT-7B", ...
The dropdown defaults to "Two random models", in which case the behavior of the application is identical to that before this change. Otherwise, the model preferred by the user will be included in the two models dueling. The user will still not know which of the left and right models is the model they chose before voting.