### PR TITLE
Support for benchmarking of diffusion models

### DIFF
--- a/deployment/benchmark.Dockerfile
+++ b/deployment/benchmark.Dockerfile
@@ -30,6 +30,11 @@ RUN cd /workspace \
       && rm -r .git \
       && pip install -e .
 
+# Install dependencies for diffusers
+RUN cd /workspace/leaderboard
+# RUN pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+RUN pip install datasets diffusers transformers accelerate torchmetrics[image] zeus-ml tyro
+
 # Apply patches
 # Salesforce xgen inference fix (https://github.com/lm-sys/FastChat/pull/2350)
 RUN cd /root/.local/miniconda3/lib/python3.9/site-packages \
@@ -37,6 +42,7 @@ RUN cd /root/.local/miniconda3/lib/python3.9/site-packages \
 
 # Where all the weights downloaded from Hugging Face Hub will go to
 ENV TRANSFORMERS_CACHE=/data/leaderboard/hfcache
+ENV HF_HOME=/data/leaderboard/hfcache
 
 # So that docker exec container python scripts/benchmark.py will work
 WORKDIR /workspace/leaderboard

--- a/deployment/benchmark.Dockerfile
+++ b/deployment/benchmark.Dockerfile
@@ -30,11 +30,6 @@ RUN cd /workspace \
       && rm -r .git \
       && pip install -e .
 
-# Install dependencies for diffusers
-RUN cd /workspace/leaderboard
-# RUN pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
-RUN pip install datasets diffusers transformers accelerate torchmetrics[image] zeus-ml tyro
-
 # Apply patches
 # Salesforce xgen inference fix (https://github.com/lm-sys/FastChat/pull/2350)
 RUN cd /root/.local/miniconda3/lib/python3.9/site-packages \

--- a/pegasus/benchmark_diffusion.yaml
+++ b/pegasus/benchmark_diffusion.yaml
@@ -1,0 +1,22 @@
+# This YAML dictionary will expand into 8 (models) x 6 (batch sizes) = 48 job commands,
+# where {{ model }} and {{ batch_size }} are filled in with all possible combinations.
+# {{ gpu }} is defined in `hosts.yaml`, and will be filled in when Pegasus
+# determines the specific node and gpu the generated job command will run on.
+- command:
+    - docker exec leaderboard{{ gpu }} python scripts/diffusion/benchmark.py --model {{ model }} --batch_size {{ batch_size }} --warmup
+  model:
+    - runwayml/stable-diffusion-v1-5
+    - stabilityai/stable-diffusion-xl-base-1.0
+    - stabilityai/stable-diffusion-2-1
+    - prompthero/openjourney
+    - kakaobrain/karlo-v1-alpha
+    - kandinsky-community/kandinsky-2-2-decoder
+    - CompVis/ldm-text2im-large-256
+    - SimianLuo/LCM_Dreamshaper_v7
+  batch_size:
+    - 1
+    - 2
+    - 4
+    - 8
+    - 16
+    - 32

--- a/scripts/diffusion/benchmark.py
+++ b/scripts/diffusion/benchmark.py
@@ -1,0 +1,101 @@
+import torch, gc, tyro
+import numpy as np
+from diffusers import DiffusionPipeline, AutoPipelineForText2Image
+from zeus.monitor import ZeusMonitor
+from utils import get_logger, CsvHandler
+from metrics import *
+
+# default parameters
+DEVICE = "cuda"
+WEIGHT_DTYPE = torch.float16
+SEED = 0
+OUTPUT_FILE = "results.csv"
+
+
+def get_pipeline(model, pipeline=DiffusionPipeline, device=DEVICE, weight_dtype=WEIGHT_DTYPE):
+    try:
+        return AutoPipelineForText2Image.from_pretrained(model, torch_dtype=weight_dtype, safety_checker = None).to(device)
+    except:
+        return pipeline.from_pretrained(model, torch_dtype=weight_dtype, safety_checker = None).to(device)
+    
+def gpu_warmup():
+    logger = get_logger()
+    logger.info("Warming up GPU")
+    generator = torch.manual_seed(2)
+    pipeline = get_pipeline("runwayml/stable-diffusion-v1-5")
+    prompts = load_prompts_clip(10)
+    _ = pipeline(prompts, num_images_per_prompt=10, generator=generator, output_type="numpy").images
+
+
+
+
+def benchmark(
+        model: str,
+        prompt_size: int = 0,
+        batch_size: int = 1,
+        output_file: str = OUTPUT_FILE,
+        device: str = DEVICE,
+        seed: int = SEED, 
+        weight_dtype: torch.dtype = WEIGHT_DTYPE,
+        write_header: bool = False,
+        warmup: bool = False,
+        settings: dict = {}
+) -> None:
+    """
+        Main benchmark script.
+    """
+    logger = get_logger()
+    logger.info("Running benchmark for model: " + model)
+
+    csv_handler = CsvHandler(output_file)
+    if write_header:
+        csv_handler.write_header(
+            ["model", "GPU", "image_num", "batch_size", "clip_score", "avg_latency(s)", "avg_energy(J)", "peak_memory(GB)"])
+
+    prompts, batched_prompts = load_prompts_clip(prompt_size, batch_size, seed)
+    logger.info("Loaded prompts")
+
+    if warmup:
+        gpu_warmup()
+
+    generator = torch.manual_seed(seed)
+    monitor = ZeusMonitor(gpu_indices=[torch.cuda.current_device()])
+    pipeline = get_pipeline(model, device=device, weight_dtype=weight_dtype)
+
+    torch.cuda.empty_cache()
+    gc.collect()
+    torch.cuda.reset_peak_memory_stats(device=device)
+
+    monitor.begin_window("generate")
+    images = []
+    for batch in batched_prompts:
+        image = pipeline(batch, generator=generator, output_type="np", **settings).images
+        images.append(image)
+    images = np.concatenate(images)
+    result_monitor = monitor.end_window("generate")
+
+    peak_memory = torch.cuda.max_memory_allocated(device=device)
+
+    clip_score = calculate_clip_score(images, prompts)
+
+    result = {
+        'model' : model,
+        'GPU' : torch.cuda.get_device_name(torch.cuda.current_device()),
+        'image_num' : prompt_size,
+        'batch_size' : batch_size,
+        'clip_score' : clip_score,
+        'avg_latency' : round(result_monitor.time/prompt_size, 2),
+        'avg_energy' : round(result_monitor.total_energy/prompt_size, 2),
+        'peak_memory' : round(peak_memory/1024/1024/1024, 4)
+    }
+
+    logger.info("Results for model " + model + ":")
+    logger.info(result)
+
+    csv_handler.write_results(result)
+
+    logger.info("Finished benchmarking for " + model)
+
+
+if __name__ == "__main__":
+    tyro.cli(benchmark)

--- a/scripts/diffusion/metrics.py
+++ b/scripts/diffusion/metrics.py
@@ -25,7 +25,7 @@ def load_prompts(num_prompts, batch_size, seed):
         num_prompts = len(prompts)
     else:
         prompts = prompts.shuffle(seed=seed)
-    prompts = [prompt["Prompt"] for prompt in prompts[:num_prompts]]
+    prompts = prompts[:num_prompts]["Prompt"]
     return prompts, [prompts[i:i + batch_size] for i in range(0, len(prompts), batch_size)]
 
 def calculate_clip_score(images, prompts):

--- a/scripts/diffusion/metrics.py
+++ b/scripts/diffusion/metrics.py
@@ -4,43 +4,51 @@ from datasets import load_dataset
 import torch
 from torchmetrics.functional.multimodal import clip_score
 
+
 def load_prompts(num_prompts, batch_size):
     """Generate prompts for CLIP Score metric.
-    
+
     Args:
         num_prompts (int): number of prompts to generate.
             If num_prompts == 0, returns all prompts instead.
         batch_size (int): batch size for prompts
-    
+
     Returns:
         A tuple (prompts, batched_prompts) where prompts is a list of prompts
         of length num_prompts (if num_prompts != 0) or the list of all prompts
-        (if num_prompts == 0), and batched_prompts is the list of prompts, 
+        (if num_prompts == 0), and batched_prompts is the list of prompts,
         batched into chunks of size batch_size each.
     """
-    prompts = load_dataset("nateraw/parti-prompts", split='train')
+    prompts = load_dataset("nateraw/parti-prompts", split="train")
     if num_prompts == 0:
         num_prompts = len(prompts)
     else:
         prompts = prompts.shuffle()
     prompts = prompts[:num_prompts]["Prompt"]
-    batched_prompts = [prompts[i:i + batch_size] for i in range(0, len(prompts), batch_size)]
+    batched_prompts = [
+        prompts[i : i + batch_size] for i in range(0, len(prompts), batch_size)
+    ]
     if len(batched_prompts[-1]) < batch_size:
         batched_prompts = batched_prompts[:-1]
     prompts = [prompt for batch in batched_prompts for prompt in batch]
     return prompts, batched_prompts
 
+
 def calculate_clip_score(images, prompts):
-    """Calculate CLIP Score metric. 
+    """Calculate CLIP Score metric.
 
     Args:
         images (np.ndarray): array of images
         prompts (list): list of prompts, assumes same size as images
-    
+
     Returns:
         The clip score across all images and prompts as a float.
     """
-    clip_score_fn = partial(clip_score, model_name_or_path="openai/clip-vit-base-patch16")
+    clip_score_fn = partial(
+        clip_score, model_name_or_path="openai/clip-vit-base-patch16"
+    )
     images_int = (images * 255).astype("uint8")
-    clip = clip_score_fn(torch.from_numpy(images_int).permute(0, 3, 1, 2), prompts).detach()
+    clip = clip_score_fn(
+        torch.from_numpy(images_int).permute(0, 3, 1, 2), prompts
+    ).detach()
     return float(clip)

--- a/scripts/diffusion/metrics.py
+++ b/scripts/diffusion/metrics.py
@@ -1,54 +1,44 @@
+from functools import partial
+
 from datasets import load_dataset
 import torch
 from torchmetrics.functional.multimodal import clip_score
-from torchmetrics.image.fid import FrechetInceptionDistance
-from torchvision.transforms import functional as F
-from torchvision import transforms
-from functools import partial
-import random
-from utils import get_logger
 
-def load_prompts_clip(size, batch_size, seed):
-    """Generate prompts for CLIP Score metric"""
+def load_prompts(num_prompts, batch_size, seed):
+    """Generate prompts for CLIP Score metric.
+    
+    Args:
+        num_prompts (int): number of prompts to generate.
+            If num_prompts == 0, returns all prompts instead.
+        batch_size (int): batch size for prompts
+        seed (int): seed for the RNG used to shuffle prompts,
+            ignored if num_prompts == 0
+    
+    Returns:
+        A tuple (prompts, batched_prompts) where prompts is a list of prompts
+        of length num_prompts (if num_prompts != 0) or the list of all prompts
+        (if num_prompts == 0), and batched_prompts is the list of prompts, 
+        batched into chunks of size batch_size each.
+    """
     prompts = load_dataset("nateraw/parti-prompts", split='train')
-    if size == 0:
-        size = len(prompts)
+    if num_prompts == 0:
+        num_prompts = len(prompts)
     else:
-        random.seed(seed)
-        prompts = prompts.shuffle()
-    prompts = [prompts[i]["Prompt"] for i in range(size)]
+        prompts = prompts.shuffle(seed=seed)
+    prompts = [prompt["Prompt"] for prompt in prompts[:num_prompts]]
     return prompts, [prompts[i:i + batch_size] for i in range(0, len(prompts), batch_size)]
 
-def load_prompts_fid(size):
-    """Generate prompts for FID metric"""
-    prompts = load_dataset("nlphuji/mscoco_2014_5k_test_image_text_retrieval", split='test')
-    prompts = prompts.shuffle()
-    return ([random.choice(prompts[i]["caption"]) for i in range(size)], [prompts[i]["image"] for i in range(size)])
-
 def calculate_clip_score(images, prompts):
-    """Calculate CLIP Score metric, assumes images and prompts have same size"""
+    """Calculate CLIP Score metric. 
+
+    Args:
+        images (np.ndarray): array of images
+        prompts (list): list of prompts, assumes same size as images
+    
+    Returns:
+        The clip score across all images and prompts as a float.
+    """
     clip_score_fn = partial(clip_score, model_name_or_path="openai/clip-vit-base-patch16")
     images_int = (images * 255).astype("uint8")
     clip = clip_score_fn(torch.from_numpy(images_int).permute(0, 3, 1, 2), prompts).detach()
-    return round(float(clip), 2)
-
-def calculate_fid_score(gen_images, real_images):
-    """Calculate FID Score metric"""
-    logger = get_logger()
-
-    gen_images = torch.tensor(gen_images).permute(0, 3, 1, 2)  
-    logger.info(gen_images.shape) 
-    image_shape = (gen_images.shape[2], gen_images.shape[3])
-
-    def preprocess_image(image):
-        totensor = transforms.ToTensor()
-        image = totensor(image).unsqueeze(0)
-        image = F.center_crop(image, image_shape) / 255.0
-        return image
-    real_images = torch.cat([preprocess_image(image) for image in real_images])
-
-    fid = FrechetInceptionDistance(normalize=True)
-    logger.info(real_images.shape)
-    fid.update(real_images, real=True)
-    fid.update(gen_images, real=False)
-    return round(float(fid.compute()), 2)
+    return float(clip)

--- a/scripts/diffusion/metrics.py
+++ b/scripts/diffusion/metrics.py
@@ -1,0 +1,54 @@
+from datasets import load_dataset
+import torch
+from torchmetrics.functional.multimodal import clip_score
+from torchmetrics.image.fid import FrechetInceptionDistance
+from torchvision.transforms import functional as F
+from torchvision import transforms
+from functools import partial
+import random
+from utils import get_logger
+
+def load_prompts_clip(size, batch_size, seed):
+    """Generate prompts for CLIP Score metric"""
+    prompts = load_dataset("nateraw/parti-prompts", split='train')
+    if size == 0:
+        size = len(prompts)
+    else:
+        random.seed(seed)
+        prompts = prompts.shuffle()
+    prompts = [prompts[i]["Prompt"] for i in range(size)]
+    return prompts, [prompts[i:i + batch_size] for i in range(0, len(prompts), batch_size)]
+
+def load_prompts_fid(size):
+    """Generate prompts for FID metric"""
+    prompts = load_dataset("nlphuji/mscoco_2014_5k_test_image_text_retrieval", split='test')
+    prompts = prompts.shuffle()
+    return ([random.choice(prompts[i]["caption"]) for i in range(size)], [prompts[i]["image"] for i in range(size)])
+
+def calculate_clip_score(images, prompts):
+    """Calculate CLIP Score metric, assumes images and prompts have same size"""
+    clip_score_fn = partial(clip_score, model_name_or_path="openai/clip-vit-base-patch16")
+    images_int = (images * 255).astype("uint8")
+    clip = clip_score_fn(torch.from_numpy(images_int).permute(0, 3, 1, 2), prompts).detach()
+    return round(float(clip), 2)
+
+def calculate_fid_score(gen_images, real_images):
+    """Calculate FID Score metric"""
+    logger = get_logger()
+
+    gen_images = torch.tensor(gen_images).permute(0, 3, 1, 2)  
+    logger.info(gen_images.shape) 
+    image_shape = (gen_images.shape[2], gen_images.shape[3])
+
+    def preprocess_image(image):
+        totensor = transforms.ToTensor()
+        image = totensor(image).unsqueeze(0)
+        image = F.center_crop(image, image_shape) / 255.0
+        return image
+    real_images = torch.cat([preprocess_image(image) for image in real_images])
+
+    fid = FrechetInceptionDistance(normalize=True)
+    logger.info(real_images.shape)
+    fid.update(real_images, real=True)
+    fid.update(gen_images, real=False)
+    return round(float(fid.compute()), 2)

--- a/scripts/diffusion/utils.py
+++ b/scripts/diffusion/utils.py
@@ -1,0 +1,61 @@
+import sys, csv
+import logging
+
+def get_logger(
+    level: int = logging.INFO,
+    propagate: bool = False,
+) -> logging.Logger:
+    """Get a logger with the given name with some formatting configs."""
+    logger = logging.getLogger("diffusion-benchmarks")
+    logger.propagate = propagate
+    logger.setLevel(level)
+    if not len(logger.handlers):
+        formatter = logging.Formatter(
+            "[%(asctime)s] %(message)s", datefmt='%m-%d %H:%M:%S'
+        )
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    return logger
+
+class CsvHandler:
+    def __init__(self, file_name, header=None):
+        self.file_name = file_name
+        self.header = header
+        self.file = None
+
+    def open_file(self):
+        try:
+            self.file = open(self.file_name, mode='a', newline='\n', encoding='utf-8')
+            self.csv_writer = csv.writer(self.file)
+
+            if self.header:
+                self.csv_writer.writerow(self.header)
+
+            print(f"File '{self.file_name}' opened successfully for writing.")
+        except Exception as e:
+            print(f"Error opening file '{self.file_name}': {e}")
+
+    def write_row(self, data):
+        try:
+            self.csv_writer.writerow(data)
+        except Exception as e:
+            print(f"Error writing to file '{self.file_name}': {e}")
+
+    def close_file(self):
+        try:
+            if self.file:
+                self.file.close()
+                print(f"File '{self.file_name}' closed successfully.")
+        except Exception as e:
+            print(f"Error closing file '{self.file_name}': {e}")
+
+    def write_header(self, data):
+        self.open_file()
+        self.write_row(data)
+        self.close_file()
+
+    def write_results(self, result):
+        self.open_file()
+        self.write_row(list(result.values()))
+        self.close_file()

--- a/scripts/diffusion/utils.py
+++ b/scripts/diffusion/utils.py
@@ -1,5 +1,6 @@
-import sys, csv
+import csv
 import logging
+import sys
 
 def get_logger(
     level: int = logging.INFO,
@@ -25,30 +26,21 @@ class CsvHandler:
         self.file = None
 
     def open_file(self):
-        try:
-            self.file = open(self.file_name, mode='a', newline='\n', encoding='utf-8')
-            self.csv_writer = csv.writer(self.file)
+        self.file = open(self.file_name, mode='a', newline='\n', encoding='utf-8')
+        self.csv_writer = csv.writer(self.file)
 
-            if self.header:
-                self.csv_writer.writerow(self.header)
+        if self.header:
+            self.csv_writer.writerow(self.header)
 
-            print(f"File '{self.file_name}' opened successfully for writing.")
-        except Exception as e:
-            print(f"Error opening file '{self.file_name}': {e}")
+        print(f"File '{self.file_name}' opened successfully for writing.")
 
     def write_row(self, data):
-        try:
-            self.csv_writer.writerow(data)
-        except Exception as e:
-            print(f"Error writing to file '{self.file_name}': {e}")
+        self.csv_writer.writerow(data)
 
     def close_file(self):
-        try:
-            if self.file:
-                self.file.close()
-                print(f"File '{self.file_name}' closed successfully.")
-        except Exception as e:
-            print(f"Error closing file '{self.file_name}': {e}")
+        if self.file:
+            self.file.close()
+            print(f"File '{self.file_name}' closed successfully.")
 
     def write_header(self, data):
         self.open_file()

--- a/scripts/diffusion/utils.py
+++ b/scripts/diffusion/utils.py
@@ -2,6 +2,7 @@ import csv
 import logging
 import sys
 
+
 def get_logger(
     level: int = logging.INFO,
     propagate: bool = False,
@@ -12,12 +13,13 @@ def get_logger(
     logger.setLevel(level)
     if not len(logger.handlers):
         formatter = logging.Formatter(
-            "[%(asctime)s] %(message)s", datefmt='%m-%d %H:%M:%S'
+            "[%(asctime)s] %(message)s", datefmt="%m-%d %H:%M:%S"
         )
         handler = logging.StreamHandler(sys.stdout)
         handler.setFormatter(formatter)
         logger.addHandler(handler)
     return logger
+
 
 class CsvHandler:
     def __init__(self, file_name, header=None):
@@ -26,7 +28,7 @@ class CsvHandler:
         self.file = None
 
     def open_file(self):
-        self.file = open(self.file_name, mode='a', newline='\n', encoding='utf-8')
+        self.file = open(self.file_name, mode="a", newline="\n", encoding="utf-8")
         self.csv_writer = csv.writer(self.file)
 
         if self.header:

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,19 @@ extras_require = {
         "gradio==3.39.0",
         "text_generation @ git+https://github.com/ml-energy/text_generation_energy@master",
     ],
-    "benchmark": ["zeus-ml", "fschat==0.2.23", "torch==2.0.1", "tyro", "rich",
-                  "datasets==2.15.0", "diffusers==0.23.1", "transformers==4.35.2", 
-                  "accelerat==0.24.1", "torchmetrics==1.2.0", "pillow==10.1.0"],
+    "benchmark": [
+        "zeus-ml",
+        "fschat==0.2.23",
+        "torch==2.0.1",
+        "tyro",
+        "rich",
+        "datasets==2.15.0",
+        "diffusers==0.23.1",
+        "transformers==4.35.2",
+        "accelerat==0.24.1",
+        "torchmetrics==1.2.0",
+        "pillow==10.1.0",
+    ],
     "dev": ["pytest"],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ extras_require = {
         "text_generation @ git+https://github.com/ml-energy/text_generation_energy@master",
     ],
     "benchmark": ["zeus-ml", "fschat==0.2.23", "torch==2.0.1", "tyro", "rich",
-                  "datasets", "diffusers", "transformers", "accelerate", "torchmetrics[image]"],
+                  "datasets==2.15.0", "diffusers==0.23.1", "transformers==4.35.2", 
+                  "accelerat==0.24.1", "torchmetrics==1.2.0", "pillow==10.1.0"],
     "dev": ["pytest"],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ extras_require = {
         "gradio==3.39.0",
         "text_generation @ git+https://github.com/ml-energy/text_generation_energy@master",
     ],
-    "benchmark": ["zeus-ml", "fschat==0.2.23", "torch==2.0.1", "tyro", "rich"],
+    "benchmark": ["zeus-ml", "fschat==0.2.23", "torch==2.0.1", "tyro", "rich",
+                  "datasets", "diffusers", "transformers", "accelerate", "torchmetrics[image]"],
     "dev": ["pytest"],
 }
 


### PR DESCRIPTION
This PR includes the current progress on the benchmark script for diffusion models. The scripts are located in `scripts/diffusion/` and `benchmark.Dockerfile` is modified to add dependency for HF diffusers.

### How to run
After building the container, use this to run the container:
```
docker run -it \
    --name diffusion \
    -v /data/diffusion:/data/leaderboard/hfcache \
    --gpus '"device=0"' \
    --env NVIDIA_DISABLE_REQUIRE=1 \
    diffusion-benchmark bash
```

The script can be run either from command line:
```
python3 benchmark.py --model "runwayml/stable-diffusion-v1-5" --prompt_size 128 --batch_size 2
```

or through calling from another python script:
```
benchmark("runwayml/stable-diffusion-v1-5", prompt_size=32, batch_size=8, settings={"num_inference_steps":20})
```

### TODO
We need to figure out how to merge this script with current LLM benchmarking, and how to present the data.